### PR TITLE
Fix deploy job permissions for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,9 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- Added explicit permissions to deploy job
- Required for successful GitHub Pages deployment
- Jobs need pages:write and id-token:write permissions