### PR TITLE
Fix inclination conversion for pass calculations

### DIFF
--- a/starlink/docs/app.js
+++ b/starlink/docs/app.js
@@ -1892,7 +1892,7 @@
       if (!this.satrec)
         return null;
       return {
-        inclination: degreesLat(this.satrec.inclo),
+        inclination: radiansToDegrees(this.satrec.inclo),
         meanMotion: this.satrec.no * 1440 / (2 * Math.PI),
         // Convert rad/min to rev/day
         eccentricity: this.satrec.ecco,

--- a/starlink/src/orbit/propagator.ts
+++ b/starlink/src/orbit/propagator.ts
@@ -62,7 +62,7 @@ export class SatellitePropagator {
     if (!this.satrec) return null;
 
     return {
-      inclination: satellite.degreesLat(this.satrec.inclo),
+      inclination: satellite.radiansToDegrees(this.satrec.inclo),
       meanMotion: this.satrec.no * 1440 / (2 * Math.PI), // Convert rad/min to rev/day
       eccentricity: this.satrec.ecco,
       period: (2 * Math.PI) / this.satrec.no // minutes


### PR DESCRIPTION
### Motivation
- This change targets the `starlink` prototype to fix a runtime error during pass calculation that reported `Latitude radians must be in range [-pi/2; pi/2]`.
- The error was caused by an incorrect conversion of the orbital inclination value when extracting orbital elements for visibility checks.

### Description
- Replace `satellite.degreesLat(this.satrec.inclo)` with `satellite.radiansToDegrees(this.satrec.inclo)` in `starlink/src/orbit/propagator.ts` to correctly convert inclination radians to degrees.
- Rebuild the bundled client script so the fix is included in `starlink/docs/app.js`.
- Changes touch `starlink/src/orbit/propagator.ts` and the generated `starlink/docs/app.js` bundle.

### Testing
- Ran the project build with `npm run build` (which runs `tsc && npm run bundle`) and it completed successfully.
- The produced bundle `docs/app.js` was rebuilt and updated to include the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69641c6ca5dc832382a5d4887123bb7e)