### PR TITLE
Restrict scheduled workflow runs to main branch only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ concurrency:
 
 jobs:
   build:
+    # Only run scheduled jobs on main branch
+    if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -136,6 +138,8 @@ jobs:
           path: .
 
   deploy:
+    # Only run scheduled jobs on main branch
+    if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Problem:
- Scheduled workflow (every 6 hours) was running on ALL branches
- Feature branches tried to deploy to GitHub Pages on schedule
- This caused "HttpError: Not Found" and "Get Pages site failed" errors
- User received failure emails every 6 hours from feature branches

Root Cause:
- Scheduled cron triggers run on the default branch but use the workflow file from each branch
- The workflow had no branch filter for scheduled events
- Feature branches would attempt (and fail) to deploy to Pages

Solution:
- Add job-level condition to both build and deploy jobs: if: github.event_name != 'schedule' || github.ref == 'refs/heads/main'

This means:
- Push events: Run on any branch (main, claude/*)
- Manual workflow_dispatch: Run on any branch
- Scheduled events: Run ONLY on main branch

Result:
✅ Feature branches can still deploy on push/manual trigger ✅ Scheduled updates only run on main branch
✅ No more failure emails from scheduled runs on feature branches ✅ Main branch gets automatic updates every 6 hours as intended

The workflow will now skip gracefully if triggered by schedule on a non-main branch, preventing the GitHub Pages deployment errors.